### PR TITLE
handle repo with no tags

### DIFF
--- a/tasks/release_plugin.js
+++ b/tasks/release_plugin.js
@@ -99,7 +99,8 @@ module.exports = function (grunt) {
 
         cp.exec(lastTagCommand, {cwd: options.repo}, function (err, lastTag) {
             if (err) {
-                grunt.log.error('Repository does not contain tags');
+                grunt.log.error('Repository does not contain tags, defaulting to version 0.0.0');
+                checkLastCommit('0.0.0')
             }
 
             checkLastCommit(lastTag);

--- a/tasks/release_plugin.js
+++ b/tasks/release_plugin.js
@@ -100,10 +100,10 @@ module.exports = function (grunt) {
         cp.exec(lastTagCommand, {cwd: options.repo}, function (err, lastTag) {
             if (err) {
                 grunt.log.error('Repository does not contain tags, defaulting to version 0.0.0');
-                checkLastCommit('0.0.0')
+                checkLastCommit('0.0.0');
+            } else {
+                checkLastCommit(lastTag);
             }
-
-            checkLastCommit(lastTag);
         });
     });
 

--- a/test/release_plugin_test.js
+++ b/test/release_plugin_test.js
@@ -19,8 +19,7 @@ function getJsonFromOutput(output) {
 
 function setUpTests(additionalCommand, done) {
     var createRepoWithOneTagCommand = 'cd test; npm install; mkdir test-repo; cd test-repo; git init; ' +
-        'touch initial-file.js; git add initial-file.js; git commit -m "test"; ' +
-        'git tag -a test-1.1.1 -m "test-1.1.1"; ' + additionalCommand;
+        'touch initial-file.js; git add initial-file.js; git commit -m "test"; ' + additionalCommand;
 
     cp.exec(createRepoWithOneTagCommand, function () {
         done();
@@ -37,7 +36,7 @@ function tearDownTests(callback) {
 
 exports.release_plugin_release = {
     setUp: function (done) {
-        setUpTests('', done);
+        setUpTests('git tag -a test-1.1.1 -m "test-1.1.1"; ', done);
     },
 
     tearDown: tearDownTests,
@@ -78,7 +77,7 @@ exports.release_plugin_release = {
 
 exports.release_plugin_snapshot = {
     setUp: function (done) {
-        setUpTests('touch file.js; git add file.js; git commit -m "test"', done);
+        setUpTests('git tag -a test-1.1.1 -m "test-1.1.1"; ' + 'touch file.js; git add file.js; git commit -m "test"', done);
     },
 
     tearDown: tearDownTests,
@@ -112,6 +111,47 @@ exports.release_plugin_snapshot = {
 
         callGrunt('gruntfile.js', 'compress', function () {
             test.ok(grunt.file.exists('test/target/universal/some-name-1.1.2-SNAPSHOT.zip'), 'should make zip file with snapshot version');
+            test.done();
+        });
+    }
+};
+
+exports.release_plugin_snapshot_no_tag = {
+    setUp: function (done) {
+        setUpTests('', done);
+    },
+
+    tearDown: tearDownTests,
+
+    currentVersion: function (test) {
+        test.expect(1);
+
+        callGrunt('gruntfile.js', 'currentVersion', function (error, stdout) {
+            var expected = '{"currentVersion":"0.0.1-SNAPSHOT"}',
+            actual = getJsonFromOutput(stdout);
+
+            test.equal(actual, expected, 'should return current snapshot project version');
+            test.done();
+        });
+    },
+
+    metadata: function (test) {
+        test.expect(1);
+
+        callGrunt('gruntfile.js', 'metadata', function (error, stdout) {
+            var expected = '{"version":"0.0.1-SNAPSHOT","name":"some-name","domain":"some-domain"}',
+            actual = getJsonFromOutput(stdout);
+
+            test.equal(actual, expected, 'should return project metadata with snapshot version');
+            test.done();
+        });
+    },
+
+    compress: function (test) {
+        test.expect(1);
+
+        callGrunt('gruntfile.js', 'compress', function () {
+            test.ok(grunt.file.exists('test/target/universal/some-name-0.0.1-SNAPSHOT.zip'), 'should make zip file with snapshot version');
             test.done();
         });
     }

--- a/test/release_plugin_test.js
+++ b/test/release_plugin_test.js
@@ -77,7 +77,7 @@ exports.release_plugin_release = {
 
 exports.release_plugin_snapshot = {
     setUp: function (done) {
-        setUpTests('git tag -a test-1.1.1 -m "test-1.1.1"; ' + 'touch file.js; git add file.js; git commit -m "test"', done);
+        setUpTests('git tag -a test-1.1.1 -m "test-1.1.1"; touch file.js; git add file.js; git commit -m "test"', done);
     },
 
     tearDown: tearDownTests,
@@ -130,7 +130,7 @@ exports.release_plugin_snapshot_no_tag = {
             var expected = '{"currentVersion":"0.0.1-SNAPSHOT"}',
             actual = getJsonFromOutput(stdout);
 
-            test.equal(actual, expected, 'should return current snapshot project version');
+            test.equal(actual, expected, 'should return "0.0.1-SNAPSHOT" project version');
             test.done();
         });
     },
@@ -142,7 +142,7 @@ exports.release_plugin_snapshot_no_tag = {
             var expected = '{"version":"0.0.1-SNAPSHOT","name":"some-name","domain":"some-domain"}',
             actual = getJsonFromOutput(stdout);
 
-            test.equal(actual, expected, 'should return project metadata with snapshot version');
+            test.equal(actual, expected, 'should return project metadata with "0.0.1-SNAPSHOT" version');
             test.done();
         });
     },
@@ -151,7 +151,7 @@ exports.release_plugin_snapshot_no_tag = {
         test.expect(1);
 
         callGrunt('gruntfile.js', 'compress', function () {
-            test.ok(grunt.file.exists('test/target/universal/some-name-0.0.1-SNAPSHOT.zip'), 'should make zip file with snapshot version');
+            test.ok(grunt.file.exists('test/target/universal/some-name-0.0.1-SNAPSHOT.zip'), 'should make zip file with "0.0.1-SNAPSHOT" version');
             test.done();
         });
     }


### PR DESCRIPTION
Before this change a version for a repo with no tags could not be obtained.

This change sets the default version to 0.0.0 when no tag exists which in turn produces version 0.0.1-SNAPSHOT when run.
