### PR TITLE
support commit distance in snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Default value: `{}`
 
 An object with version (which will be replaced) any any other stuff returned by metadata task, usually `package.json`
 
+#### options.useDistance
+Type: `Boolean`
+Default value: `false`
+
+A snapshot version will include the count of commits from the last tag in it.
+
 ### Usage Examples
 
 #### Default Options
@@ -64,7 +70,8 @@ grunt.initConfig({
   release_plugin: {
     options: {
       repo: ".",
-      pkg: grunt.file.readJSON('package.json')
+      pkg: grunt.file.readJSON('package.json'),
+      useDistance: false
     },
     currentVersion: {},
     metadata: {},

--- a/test/gruntfile-distance.js
+++ b/test/gruntfile-distance.js
@@ -16,7 +16,7 @@ module.exports = function (grunt) {
             options: {
                 repo: './test-repo',
                 pkg: '<%= pkg %>',
-                useDistance: false
+                useDistance: true
             },
             currentVersion: {},
             metadata: {},

--- a/test/release_plugin_test.js
+++ b/test/release_plugin_test.js
@@ -116,3 +116,85 @@ exports.release_plugin_snapshot = {
         });
     }
 };
+
+exports.release_plugin_release_distance = {
+    setUp: function (done) {
+        setUpTests('', done);
+    },
+
+    tearDown: tearDownTests,
+
+    currentVersion: function (test) {
+        test.expect(1);
+
+        callGrunt('gruntfile-distance.js', 'currentVersion', function (error, stdout) {
+            var expected = '{"currentVersion":"1.1.1"}',
+            actual = getJsonFromOutput(stdout);
+
+            test.equal(actual, expected, 'should return current release project version');
+            test.done();
+        });
+    },
+
+    metadata: function (test) {
+        test.expect(1);
+
+        callGrunt('gruntfile-distance.js', 'metadata', function (error, stdout) {
+            var expected = '{"version":"1.1.1","name":"some-name","domain":"some-domain"}',
+            actual = getJsonFromOutput(stdout);
+
+            test.equal(actual, expected, 'should return project metadata with release version');
+            test.done();
+        });
+    },
+
+    compress: function (test) {
+        test.expect(1);
+
+        callGrunt('gruntfile-distance.js', 'compress', function () {
+            test.ok(grunt.file.exists('test/target/universal/some-name-1.1.1.zip'), 'should make zip file with release version');
+            test.done();
+        });
+    }
+};
+
+exports.release_plugin_snapshot_distance = {
+    setUp: function (done) {
+        setUpTests('touch file.js; git add file.js; git commit -m "test"', done);
+    },
+
+    tearDown: tearDownTests,
+
+    currentVersion: function (test) {
+        test.expect(1);
+
+        callGrunt('gruntfile-distance.js', 'currentVersion', function (error, stdout) {
+            var expected = '{"currentVersion":"1.1.2-SNAPSHOT1"}',
+            actual = getJsonFromOutput(stdout);
+
+            test.equal(actual, expected, 'should return current snapshot project version');
+            test.done();
+        });
+    },
+
+    metadata: function (test) {
+        test.expect(1);
+
+        callGrunt('gruntfile-distance.js', 'metadata', function (error, stdout) {
+            var expected = '{"version":"1.1.2-SNAPSHOT1","name":"some-name","domain":"some-domain"}',
+            actual = getJsonFromOutput(stdout);
+
+            test.equal(actual, expected, 'should return project metadata with snapshot version');
+            test.done();
+        });
+    },
+
+    compress: function (test) {
+        test.expect(1);
+
+        callGrunt('gruntfile-distance.js', 'compress', function () {
+            test.ok(grunt.file.exists('test/target/universal/some-name-1.1.2-SNAPSHOT1.zip'), 'should make zip file with snapshot version');
+            test.done();
+        });
+    }
+};


### PR DESCRIPTION
This introduces the option to append the distance from the current commit to the last tag to the -SNAPSHOT string. E.g. if there have been 34 commits to the branch since the last tag the suffix will be
`-SNAPSHOT34`.
